### PR TITLE
Add the correct function argument for PCI interrupt handler

### DIFF
--- a/pci/pci.c
+++ b/pci/pci.c
@@ -139,7 +139,7 @@ int32_t pci_call_interrupt_chain(int32_t handle, int32_t data)
     {
         if (interrupts[i].handle == handle)
         {
-            interrupts[i].handler(data);
+            interrupts[i].handler(interrupts[i].parameter);
 
             return 1;
         }


### PR DESCRIPTION
According to PCI-BIOS documentation PCI interrupt handlers expect
as an argument the value "parameter" which was passed with the function
pci_hook_interrupt().