### PR TITLE
Add support for the M5475EVB Board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ CFLAGS_OPTIMIZED = -mcpu=5474 \
 		-Wa,--register-prefix-optional
 LDFLAGS=
 
-TRGTDIRS= ./firebee ./m54455 ./m5484lite
+TRGTDIRS= ./firebee ./m54455 ./m5484lite ./m5475evb
 OBJDIRS=$(patsubst %, %/objs,$(TRGTDIRS))
 TOOLDIR=util
 
@@ -210,26 +210,32 @@ clean:
 
 # flags for targets
 m5484lite/bas.$(EXE): MACHINE=MACHINE_M5484LITE
+m5475evb/bas.$(EXE): MACHINE=MACHINE_M5475EVB
 m54455/bas.$(EXE): MACHINE=MACHINE_M54455
 firebee/bas.$(EXE): MACHINE=MACHINE_FIREBEE
 
 m5484lite/ram.$(EXE): MACHINE=MACHINE_M5484LITE
+m5475evb/ram.$(EXE): MACHINE=MACHINE_M5475EVB
 m54455/ram.$(EXE): MACHINE=MACHINE_M54455
 firebee/ram.$(EXE): MACHINE=MACHINE_FIREBEE
 
 m5484lite/basflash.$(EXE): MACHINE=MACHINE_M5484LITE
+m5475evb/basflash.$(EXE): MACHINE=MACHINE_M5475EVB
 m54455/basflash.$(EXE): MACHINE=MACHINE_M54455
 firebee/basflash.$(EXE): MACHINE=MACHINE_FIREBEE
 
 m5484lite/bas.$(EXE): CFLAGS += -mcpu=5484
+m5475evb/bas.$(EXE): CFLAGS += -mcpu=5474
 m54455/bas.$(EXE): CFLAGS += -mcpu=54455 -msoft-float
 firebee/bas.$(EXE): CFLAGS += -mcpu=5474
 
 m5484lite/ram.$(EXE): CFLAGS += -mcpu=5484
+m5475evb/ram.$(EXE): CFLAGS += -mcpu=5474
 m54455/ram.$(EXE): CFLAGS += -mcpu=54455 -msoft-float
 firebee/ram.$(EXE): CFLAGS += -mcpu=5474
 
 m5484lite/basflash.$(EXE): CFLAGS += -mcpu=5484
+m5475evb/basflash.$(EXE): CFLAGS += -mcpu=5474
 m54455/basflash.$(EXE): CFLAGS += -mcpu=54455 -msoft-float
 firebee/basflash.$(EXE): CFLAGS += -mcpu=5474
 
@@ -352,6 +358,8 @@ printvars:
 	$(Q)$(foreach V,$(.VARIABLES), $(if $(filter-out environment% default automatic, $(origin $V)),$(warning $V=$($V))))
 ifeq (MACHINE_M5484LITE,$$(MACHINE))
 	MNAME=m5484lite
+else ifeq (MACHINE_M5475EVB,$$(MACHINE))
+	MNAME=m5475evb
 else ifeq (MACHINE_FIREBEE,$(MACHINE))
 	MNAME=firebee
 endif

--- a/bas.lk.in
+++ b/bas.lk.in
@@ -2,6 +2,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #    include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#    include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else

--- a/basflash.lk.in
+++ b/basflash.lk.in
@@ -2,6 +2,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else

--- a/dma/dma.c
+++ b/dma/dma.c
@@ -33,6 +33,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else

--- a/exe/basflash.c
+++ b/exe/basflash.c
@@ -32,6 +32,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else

--- a/flash/flash.c
+++ b/flash/flash.c
@@ -5,6 +5,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #endif /* MACHINE_FIREBEE */
 
 #define AMD_FLASH_BUS_SHIFT     1

--- a/include/m5475e.h
+++ b/include/m5475e.h
@@ -1,0 +1,50 @@
+#ifndef _M5475E_H_
+#define _M5475E_H_
+
+/*
+ * m5475e.h
+ *
+ * preprocessor definitions for the M5475EVB machine. This file should contain nothing but preprocessor
+ * definition that evaluate to numbers. It is intended for use in C sources as well as in linker control
+ * files, so care must be taken to not break the syntax of either one.
+ * 
+ * This file is part of BaS_gcc.
+ *
+ * BaS_gcc is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BaS_gcc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BaS_gcc.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Created on: 26.02.2013
+ *      Author: Markus Fröschle
+ */
+
+#define SYSCLK                      13333333UL
+
+#define BOOTFLASH_BASE_ADDRESS      0xe0000000
+#define BOOTFLASH_SIZE              0x200000	/* 2MB Boot flash size (16MB code flash) */
+#define BOOTFLASH_BAM               (BOOTFLASH_SIZE - 1)
+
+#define SDRAM_START                 0x00000000	/* start at address 0 */
+#define SDRAM_SIZE                  0x4000000  	/* 64 MB */
+
+#ifdef COMPILE_RAM
+#define TARGET_ADDRESS              (SDRAM_START + SDRAM_SIZE - 0x200000)
+#else
+#define TARGET_ADDRESS              BOOTFLASH_BASE_ADDRESS
+#endif /* COMPILE_RAM */
+#define BFL_TARGET_ADDRESS          0x0100000           /* load address for basflash */
+
+#define DRIVER_MEM_BUFFER_SIZE      0x100000
+
+#define EMUTOS_BASE_ADDRESS         0xe0100000
+
+#endif /* _M5475E_H_ */

--- a/include/wait.h
+++ b/include/wait.h
@@ -33,6 +33,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else

--- a/net/am79c874.c
+++ b/net/am79c874.c
@@ -13,6 +13,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else

--- a/net/bcm5222.c
+++ b/net/bcm5222.c
@@ -18,6 +18,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else

--- a/net/fec.c
+++ b/net/fec.c
@@ -19,13 +19,15 @@
 #include "util.h"
 #include "wait.h"
 #include "am79c874.h"
-//#include "bcm5222.h"
+#include "bcm5222.h"
 #include <stdbool.h>
 
 #if defined(MACHINE_FIREBEE)
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else
@@ -1356,8 +1358,8 @@ void fec_eth_setup(uint8_t ch, uint8_t trcvr, uint8_t speed, uint8_t duplex, con
             dbg("PHY init completed\r\n");
         else
             dbg("PHY init failed\r\n");
-#elif defined(MACHINE_M548X)
-        bcm_5222_init(0, 0, speed, duplex);
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
+        bcm5222_init(0, 0, speed, duplex);
 #else
         fec_mii_init(ch, SYSCLK / 1000);
 #endif /* MACHINE_FIREBEE */

--- a/net/net_timer.c
+++ b/net/net_timer.c
@@ -23,6 +23,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else

--- a/pci/pci.c
+++ b/pci/pci.c
@@ -1047,7 +1047,7 @@ void init_eport(void)
             MCF_EPORT_EPPAR_EPPA6(MCF_EPORT_EPPAR_FALLING) |
         #if defined(MACHINE_FIREBEE)     /* irq5 level triggered on FireBee */
             MCF_EPORT_EPPAR_EPPA5(MCF_EPORT_EPPAR_LEVEL) |
-        #elif defined(MACHINE_M5484LITE)
+        #elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
             MCF_EPORT_EPPAR_EPPA5(MCF_EPORT_EPPAR_FALLING) |
         #endif /* MACHINE_FIREBEE */
             MCF_EPORT_EPPAR_EPPA4(MCF_EPORT_EPPAR_FALLING) |
@@ -1130,7 +1130,7 @@ void init_pci(void)
             MCF_PAD_PAR_PCIBR_PAR_PCIBR2_PCIBR2 |
             MCF_PAD_PAR_PCIBR_PAR_PCIBR1_PCIBR1 |
             MCF_PAD_PAR_PCIBR_PAR_PCIBR0_PCIBR0;
-#elif defined(MACHINE_M5484LITE)
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
     MCF_PAD_PAR_PCIBG = MCF_PAD_PAR_PCIBG_PAR_PCIBG0_PCIBG0 |
             MCF_PAD_PAR_PCIBG_PAR_PCIBG1_PCIBG1 |
             MCF_PAD_PAR_PCIBG_PAR_PCIBG2_PCIBG2 |

--- a/sys/BaS.c
+++ b/sys/BaS.c
@@ -252,7 +252,7 @@ void enable_pci_interrupts()
             FBEE_INTR_PCI_INTC |
             FBEE_INTR_PCI_INTD;
             ;
-#elif defined(MACHINE_M5484LITE)
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
     /*
      * MCF 5484 interrupts are configured at the CPLD for the FireEngine
      */
@@ -281,7 +281,7 @@ void disable_coldfire_interrupts()
 
 
 NIF nif1;
-#if defined(MACHINE_M5484LITE)
+#if defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
     /*
      * on the MCF 5484 LITEKIT, the second FEC interface is usable
      */

--- a/sys/driver_mem.c
+++ b/sys/driver_mem.c
@@ -22,6 +22,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else

--- a/sys/exceptions.S
+++ b/sys/exceptions.S
@@ -25,6 +25,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #endif /* MACHINE_FIREBEE */
 
 	.extern	__SUP_SP

--- a/sys/mmu.c
+++ b/sys/mmu.c
@@ -41,6 +41,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else
@@ -188,7 +190,7 @@ static struct virt_to_phys translation[] =
     { 0x00f00000, 0x00100000, 0xff000000 },     /* map Falcon I/O area to FPGA */
     { 0x01000000, 0x1f000000, 0x00000000 },     /* map rest of ram virt = phys */
 };
-#elif defined(MACHINE_M5484LITE)
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
 static struct virt_to_phys translation[] =
 {
     /* virtual  , length    , offset    */
@@ -527,7 +529,7 @@ void mmu_init(void)
         }
         pages[i].locked = 0;                /* not locked */
 
-#elif defined(MACHINE_M5484LITE)
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
         if (addr >= 0x60000000UL && addr < 0x70000000UL)        /* Compact Flash on the m5484lite */
         {
             pages[i].cache_mode = CACHE_NOCACHE_PRECISE;
@@ -631,7 +633,7 @@ void mmu_init(void)
             ACR_ADMSK(0x7f) |                       /* cover 2GB area from 0x80000000 to 0xffffffff */
             // ACR_BA(PCI_MEMORY_OFFSET));             /* (equals area from 3 to 4 GB */
             ACR_BA(0xe0000000));
-#elif defined(MACHINE_M5484LITE)
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
             ACR_ADMSK(0x7f) |                       /* cover 2 GB area from 0x80000000 to 0xffffffff */
             // ACR_BA(PCI_MEMORY_OFFSET));
             ACR_BA(0xe0000000));
@@ -649,7 +651,7 @@ void mmu_init(void)
             ACR_CM(0) |
 #if defined(MACHINE_FIREBEE)
             ACR_CM(ACR_CM_CACHEABLE_WT) |
-#elif defined(MACHINE_M5484LITE)
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
             ACR_CM(ACR_CM_CACHEABLE_WT) |
 #elif defined(MACHINE_M54455)
             ACR_CM(ACR_CM_CACHEABLE_WT) |
@@ -708,7 +710,7 @@ void mmu_init(void)
     flags.execute = 0;
     flags.locked = 1;
     mmu_map_page(0x00f00000, 0xfff00000, MMU_PAGE_SIZE_1M, 0, &flags);
-#elif defined(MACHINE_M5484LITE)
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
     /*
      * Map m5484LITE CPLD access
      */

--- a/sys/sysinit.c
+++ b/sys/sysinit.c
@@ -41,6 +41,8 @@
 #include "firebee.h"
 #elif defined(MACHINE_M5484LITE)
 #include "m5484l.h"
+#elif defined(MACHINE_M5475EVB)
+#include "m5475e.h"
 #elif defined(MACHINE_M54455)
 #include "m54455.h"
 #else
@@ -135,7 +137,7 @@ static void init_gpio(void)
             MCF_PAD_PAR_PCIBG_PAR_PCIBG2_PCIBG2 |
             MCF_PAD_PAR_PCIBG_PAR_PCIBG1_PCIBG1 |
             MCF_PAD_PAR_PCIBG_PAR_PCIBG0_PCIBG0;
-#elif defined(MACHINE_M5484LITE)
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
     MCF_PAD_PAR_PCIBG = MCF_PAD_PAR_PCIBG_PAR_PCIBG4_PCIBG4 |
             MCF_PAD_PAR_PCIBG_PAR_PCIBG3_PCIBG3 |
             MCF_PAD_PAR_PCIBG_PAR_PCIBG2_PCIBG2 |
@@ -157,7 +159,7 @@ static void init_gpio(void)
             MCF_PAD_PAR_PCIBR_PAR_PCIBR2_PCIBR2 |
             MCF_PAD_PAR_PCIBR_PAR_PCIBR1_PCIBR1 |
             MCF_PAD_PAR_PCIBR_PAR_PCIBR0_PCIBR0;
-#elif defined(MACHINE_M5484LITE)
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
     MCF_PAD_PAR_PCIBR = MCF_PAD_PAR_PCIBR_PAR_PCIBR4_PCIBR4 |
             MCF_PAD_PAR_PCIBR_PAR_PCIBR3_PCIBR3 |
             MCF_PAD_PAR_PCIBR_PAR_PCIBR2_PCIBR2 |
@@ -221,7 +223,7 @@ static void init_serial(void)
     MCF_PSC0_PSCSICR = 0;       /* PSC control register: select UART mode */
     MCF_PSC0_PSCCSR = 0xDD;     /* use TX and RX baud rate from PSC timer */
     MCF_PSC0_PSCCTUR = 0x00;    /* =\ */
-#if defined(MACHINE_FIREBEE)
+#if defined(MACHINE_FIREBEE) || defined(MACHINE_M5475EVB)
     MCF_PSC0_PSCCTLR = 36;      /* divide sys_clk by 36 => BAUD RATE = 115200 bps */
 #endif
 #if defined(MACHINE_M5484LITE)
@@ -339,7 +341,7 @@ static bool init_ddram(void)
         MCF_SDRAMC_SDMR = 0x008D0000;   /* SDMR (write to LMR) */
         MCF_SDRAMC_SDCR = 0x710D0F00;   /* SDCR (lock SDMR and enable refresh) */
 
-#elif defined(MACHINE_M5484LITE)
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
         MCF_SDRAMC_CS0CFG = 0x00000019; /* SDRAM CS0 configuration (64 Mbytes 0000_0000 - 03FF_FFFF) */
         MCF_SDRAMC_CS1CFG = 0x00000000; /* SDRAM CS1 configuration - off */
         MCF_SDRAMC_CS2CFG = 0x00000000; /* SDRAM CS2 configuration - off */
@@ -462,7 +464,7 @@ static void init_fbcs()
         | MCF_FBCS_CSCR_RDAH(1);                /* chip errata SECF077 */
     MCF_FBCS5_CSMR = MCF_FBCS_CSMR_BAM_1G;
         //| MCF_FBCS_CSMR_V;
-#elif defined(MACHINE_M5484LITE)
+#elif defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
     /* disable other FBCS for now */
     MCF_FBCS1_CSMR = 0;
     MCF_FBCS2_CSMR = 0;
@@ -996,6 +998,8 @@ void initialize_hardware(void)
     "Firebee"
 #elif MACHINE_M5484LITE
     "m5484 LITEKIT"
+#elif MACHINE_M5475EVB
+    "m5475 EVB"
 #else
     "unknown platform"
 #endif
@@ -1075,7 +1079,7 @@ void initialize_hardware(void)
     init_fbcs();
     init_ddram();
 
-#if defined(MACHINE_M5484LITE)
+#if defined(MACHINE_M5484LITE) || defined(MACHINE_M5475EVB)
     dbg("Fire Engine Control register:          %02x\r\n", * (uint8_t *) 0x61000000);
     dbg("Fire Engine interrupt register:        %02x\r\n", * (uint8_t *) 0x62000000);
     dbg("Fire Engine interrupt mask register:   %02x\r\n", * (uint8_t *) 0x63000000);


### PR DESCRIPTION
Note that this also enables bcm5222_init for M5484LITE as this previously used the invalid definition of MACHINE_M548X which isn't defined anywhere in the code base.