### PR TITLE
IDE Detection Issues

### DIFF
--- a/sys/ide.c
+++ b/sys/ide.c
@@ -88,7 +88,7 @@ int wait_ready(short ide_addr_offset)
         wait_ms(1);
         i++;
         if (i == 2000) /* 2 sec */
-            return -1;
+            return 1;
     } while (IDE_REG_STATUS & IDE_REG_STATUS_BSY);
 
     return 0;

--- a/sys/ide.c
+++ b/sys/ide.c
@@ -68,7 +68,7 @@ int32_t get_speed(short pio_cycle_time)
      *    > 128 ns slow
      */
     if (pio_cycle_time <= 0)
-            speed = -1; /* drive or card not present */
+            speed = 3; /* drive or card not present */
     else if (pio_cycle_time <= 63)
             speed = 0;
     else if (pio_cycle_time <= 96)
@@ -165,6 +165,6 @@ void set_ide_access_mode(void)
     pio_cycle_time = test_drive(IDE_2ND_INTERFACE);
     speed = get_speed(pio_cycle_time);
 #endif
-    speed = 11; /* 0b1011 (default access (3) mode not wait (+8)) */
+    speed = 3; /* 0b1011 (default access (3) mode not wait (+8)) */
     ACP_CONFIG_REG = (ACP_CONFIG_REG & 0xff0fffff) | (speed << 20);
 };


### PR DESCRIPTION
My Firebee has failed bus transceiver that goes to CF/IDE.

The issue that is happening is similar whether this transciever is currently failing or if the CF card is just unplugged.  

It starts when the IDE register is read.  pio_cycle_time is detected, on my firebee this comes back -16 due to a failed IDE bus trasceiver.  A similar situation happens when the card is unplugged as it instead just returns 0 when something times out.  

In either case the get_speed function returns -1.  In the parent function this causes one or both higher bits to be written when setting speed.  Bits 16-17 or 20-21 of F0040000 should be written with 0-3 only as in Fredi BaS but instead due to the negative return causes the higher bits to be written.  

For unknown reasons this causes dramatic interrupt failures on my firebee.   The MFP registers read 0 when read and the system locks.  What are the meaning of the higher bits and how do they cause the failure?  I don't know. 

But this PR fixes the issue.  Needs to be checked against Firebees with working IDE/CF.